### PR TITLE
Update get or create

### DIFF
--- a/harvdev_utils/chado_functions/get_or_create.py
+++ b/harvdev_utils/chado_functions/get_or_create.py
@@ -14,7 +14,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def get_or_create(session, model, ret_col=None, **kwargs):
+def get_or_create(session, model, **kwargs):
     """
     return an object or just the column of interest (i.e pub_id), if ret_col is defined.
     """
@@ -51,10 +51,7 @@ def get_or_create(session, model, ret_col=None, **kwargs):
         try:
             attempt = session.query(model).filter_by(**kwargs).one()
             log.debug('Found previous entry for %s, insert not required.' % (kwargs))
-            if ret_col is not None:  # If we're expecting a returning value from the Postgres insert.
-                return getattr(attempt, ret_col)  # Return this new value from our recently checked object.
-            else:
-                return attempt
+            return attempt, False
         except NoResultFound:
             log.debug('Previous entry for %s not found. Adding insert.' % (kwargs))
             created = model(**kwargs)
@@ -62,6 +59,4 @@ def get_or_create(session, model, ret_col=None, **kwargs):
     session.add(created)
     session.flush()
 
-    if ret_col is not None:  # If we're expecting a RETURNING value from the Postgres insert.
-        return getattr(created, ret_col)  # Return this new value from our recently added/flushed object.
-    return created
+    return created, True


### PR DESCRIPTION
- No longer takes ret_col as an input argument. 
- No longer returns a column value.
- Returns both the object from the database (an entry from a table) + either `True` (if an object was created) or `False` (if an object was not created and simply retrieved).