### PR TITLE
Fixed bug in checking for existing data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ temp.py
 
 # VSCode
 .vscode
+
+# PyCharm
+.idea

--- a/harvdev_utils/chado_functions/get_or_create.py
+++ b/harvdev_utils/chado_functions/get_or_create.py
@@ -31,14 +31,15 @@ def get_or_create(session, model, **kwargs):
 
     # Get our unique constraints. We need to query with *only* these in order to get the correct rank value.
     unique_constraints = insp.get_unique_constraints(model.__tablename__)
+    log.debug('Unique constraints are {}'.format(unique_constraints))
+
     unique_constraints_list = unique_constraints[0]['column_names']
 
     # Perform our query with only filters found as unique_constraints (minus rank).
-    constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list if k != 'rank'}
+    constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list if k != 'rank' and k in kwargs}
 
     if 'rank' in model.__table__.columns:
         log.debug('Found rank column in {}'.format(model.__tablename__))
-        log.debug('Unique constraints are {}'.format(unique_constraints))
 
         max_rank = session.query(func.max(model.rank)).\
             filter_by(**constraint_kwargs).\

--- a/harvdev_utils/chado_functions/get_or_create.py
+++ b/harvdev_utils/chado_functions/get_or_create.py
@@ -36,7 +36,7 @@ def get_or_create(session, model, **kwargs):
     unique_constraints_list = unique_constraints[0]['column_names']
 
     # Perform our query with only filters found as unique_constraints (minus rank).
-    constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list if k != 'rank' and k in kwargs}
+    constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list if k != 'rank' and k in kwargs.keys()}
 
     if 'rank' in model.__table__.columns:
         log.debug('Found rank column in {}'.format(model.__tablename__))

--- a/harvdev_utils/chado_functions/get_or_create.py
+++ b/harvdev_utils/chado_functions/get_or_create.py
@@ -29,18 +29,19 @@ def get_or_create(session, model, **kwargs):
     engine = session.get_bind()
     insp = inspect(engine)  # Used for inspecting the schema when needed.
 
+    # Get our unique constraints. We need to query with *only* these in order to get the correct rank value.
+    unique_constraints = insp.get_unique_constraints(model.__tablename__)
+    unique_constraints_list = unique_constraints[0]['column_names']
+
+    # Perform our query with only filters found as unique_constraints (minus rank).
+    constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list if k != 'rank'}
+
     if 'rank' in model.__table__.columns:
         log.debug('Found rank column in {}'.format(model.__tablename__))
-        # Get our unique constraints. We need to query with *only* these in order to get the correct rank value.
-        unique_constraints = insp.get_unique_constraints(model.__tablename__)
-        unique_constraints_list = unique_constraints[0]['column_names']
         log.debug('Unique constraints are {}'.format(unique_constraints))
 
-        # Perform our query with only filters found as unique_constraints (minus rank).
-        max_rank_kwargs = {k: kwargs[k] for k in unique_constraints_list if k != 'rank'}
-
         max_rank = session.query(func.max(model.rank)).\
-            filter_by(**max_rank_kwargs).\
+            filter_by(**constraint_kwargs).\
             one()
 
         if max_rank[0] is None:
@@ -63,7 +64,7 @@ def get_or_create(session, model, **kwargs):
             created = model(**kwargs)
     else:
         try:
-            attempt = session.query(model).filter_by(**kwargs).one()
+            attempt = session.query(model).filter_by(**constraint_kwargs).one()
             log.debug('Found previous entry for %s, insert not required.' % (kwargs))
             return attempt, False
         except NoResultFound:


### PR DESCRIPTION
I may have found a bug in `get_or_create`. Please let me know what you all think:

In situations where data attempts to be added and should not be allowed, for example:

`get_or_create(session, Dbxref, db_id=264, accession=314, description='MOD dbxref')`

The `get_or_create` function would check for the existence of an entry with `db_id=264, accession=314, description='MOD dbxref'` and give the "OK" to insert if it wasn't found. 

However, the unique constraint for the Dbxref table is on `db_id, accession, and version`, so if there is a previous entry with `db_id=264, accession=314` it will _incorrectly_ flag my attempt as valid (because it didn't find all three items) even though it still fails when it tries to flush because it violates the unique constraint policy.

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "dbxref_db_id_key"
DETAIL:  Key (db_id, accession, version)=(264, 314, ) already exists.
```

The solution is to disregard the non-constraint values when checking for the existence of an entry (this is already done for rank) which should return the "true" yes/no on whether a new entry is permitted.