### PR TITLE
Get, Create, or Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ temp.py
 
 # VSCode
 .vscode
+
+# PyCharm
+.idea

--- a/harvdev_utils/chado_functions/__init__.py
+++ b/harvdev_utils/chado_functions/__init__.py
@@ -1,5 +1,5 @@
 from .get_or_create import get_or_create
-from .get_update_or_create import get_update_or_create
+from .get_create_or_update import get_create_or_update
 from .external_lookups import ExternalLookup
 from .cvterm import get_cvterm
 from .db import get_db

--- a/harvdev_utils/chado_functions/__init__.py
+++ b/harvdev_utils/chado_functions/__init__.py
@@ -1,4 +1,5 @@
 from .get_or_create import get_or_create
+from .get_update_or_create import get_update_or_create
 from .external_lookups import ExternalLookup
 from .cvterm import get_cvterm
 from .db import get_db

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -1,0 +1,65 @@
+"""
+.. module:: get_or_create
+   :synopsis: A module to obtain a current Chado table entry or create a new one.
+
+.. moduleauthor:: Christopher Tabone ctabone@morgan.harvard.edu
+"""
+
+from sqlalchemy import (
+    inspect,
+    func)
+from sqlalchemy.orm.exc import NoResultFound
+import logging
+import sys
+
+log = logging.getLogger(__name__)
+
+
+def get_create_or_update(session, model, **kwargs):
+    """
+    :param session: The current session in use by SQL Alchemy
+    :param model: The table to be queried.
+    :param kwargs: Values for the table used for lookup (e.g. name='awesome gene')
+    :return: Both an SQL Alchemy object and True (if new object created) or False (if object retrieved)
+    """
+
+    # If rank exists in a table, we always insert our entry and increment the rank.
+    log.debug('Submitted table: {}'.format(model.__tablename__))
+    log.debug('Submitted kwargs: {}'.format(kwargs))
+    # We need to get our engine back from our session to create an inspector.
+    engine = session.get_bind()
+    insp = inspect(engine)  # Used for inspecting the schema when needed.
+
+    if 'rank' in model.__table__.columns:
+        log.critical('Rank column found in {}.'.format(model.__tablename__))
+        log.critical('This function does not work for tables with rank.')
+        sys.exit(-1)
+
+    # Get our unique constraints.
+    unique_constraints = insp.get_unique_constraints(model.__tablename__)
+    unique_constraints_list = unique_constraints[0]['column_names']
+
+    try:
+        attempt = session.query(model).filter_by(**kwargs).one()
+        log.debug('Found previous entry for %s, create or update not required.' % (kwargs))
+        return attempt, False
+    except NoResultFound:
+        log.debug('Previous entry for %s not found. Checking unique constraint query.' % (kwargs))
+
+        # Perform our query with only filters found as unique_constraints.
+        constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list}
+        log.debug('Unique constraints are {}'.format(unique_constraints))
+
+        query_result = session.query.filter_by(**constraint_kwargs).one()
+        if not query_result:
+            # If we find nothing, create a new entry with our arguments.
+            created = model(**kwargs)
+        else:
+            # If we find an entry via unique constraints, update that entry.
+            created = session.query(model).update(**kwargs)
+
+        # Add the change and flush (no commits, leave that for the main program.)
+        session.add(created)
+        session.flush()
+
+        return created, True

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -1,5 +1,5 @@
 """
-.. module:: get_or_create
+.. module:: get_create_or_update
    :synopsis: A module to obtain a current Chado table entry or create a new one.
 
 .. moduleauthor:: Christopher Tabone ctabone@morgan.harvard.edu

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -56,7 +56,10 @@ def get_create_or_update(session, model, **kwargs):
             created = model(**kwargs)
         else:
             # If we find an entry via unique constraints, update that entry.
-            created = session.query(model).update(**kwargs)
+            for key, value in kwargs.iteritems():
+                setattr(query_result, key, value)
+
+            created = query_result
 
         # Add the change and flush (no commits, leave that for the main program.)
         session.add(created)

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -1,6 +1,6 @@
 """
 .. module:: get_create_or_update
-   :synopsis: A module to obtain a current Chado table entry or create a new one.
+   :synopsis: A module to obtain a current Chado table entry, create a new one, or update an existing one.
 
 .. moduleauthor:: Christopher Tabone ctabone@morgan.harvard.edu
 """

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -47,7 +47,7 @@ def get_create_or_update(session, model, **kwargs):
         log.debug('Previous entry for %s not found. Checking unique constraint query.' % (kwargs))
 
         # Perform our query with only filters found as unique_constraints.
-        constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list}
+        constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list if k in kwargs}
         log.debug('Unique constraints are {}'.format(unique_constraints))
 
         query_result = session.query.filter_by(**constraint_kwargs).one()

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -56,7 +56,7 @@ def get_create_or_update(session, model, **kwargs):
             created = model(**kwargs)
         else:
             # If we find an entry via unique constraints, update that entry.
-            for key, value in kwargs.iteritems():
+            for key, value in kwargs.items():
                 setattr(query_result, key, value)
 
             created = query_result

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -39,11 +39,12 @@ def get_create_or_update(session, model, **kwargs):
     unique_constraints = insp.get_unique_constraints(model.__tablename__)
     unique_constraints_list = unique_constraints[0]['column_names']
 
-    try:
-        attempt = session.query(model).filter_by(**kwargs).one()
+    attempt = session.query(model).filter_by(**kwargs).one_or_none()
+    
+    if attempt:
         log.debug('Found previous entry for %s, create or update not required.' % (kwargs))
         return attempt, False
-    except NoResultFound:
+    else:
         log.debug('Previous entry for %s not found. Checking unique constraint query.' % (kwargs))
 
         # Perform our query with only filters found as unique_constraints.

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -52,7 +52,7 @@ def get_create_or_update(session, model, **kwargs):
         log.debug('Model unique constraints are {}'.format(unique_constraints))
         log.debug('New constraint kwargs for query are {}'.format(constraint_kwargs))
 
-        query_result = session.query.filter_by(**constraint_kwargs).one_or_none()
+        query_result = session.query(model).filter_by(**constraint_kwargs).one_or_none()
         if not query_result:
             # If we find nothing, create a new entry with our arguments.
             created = model(**kwargs)

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -14,7 +14,6 @@ import sys
 
 log = logging.getLogger(__name__)
 
-
 def get_create_or_update(session, model, **kwargs):
     """
     :param session: The current session in use by SQL Alchemy

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -50,7 +50,7 @@ def get_create_or_update(session, model, **kwargs):
         constraint_kwargs = {k: kwargs[k] for k in unique_constraints_list if k in kwargs}
         log.debug('Unique constraints are {}'.format(unique_constraints))
 
-        query_result = session.query.filter_by(**constraint_kwargs).one()
+        query_result = session.query.filter_by(**constraint_kwargs).one_or_none()
         if not query_result:
             # If we find nothing, create a new entry with our arguments.
             created = model(**kwargs)

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -23,7 +23,6 @@ def get_create_or_update(session, model, **kwargs):
     :return: Both an SQL Alchemy object and True (if new object created) or False (if object retrieved)
     """
 
-    # If rank exists in a table, we always insert our entry and increment the rank.
     log.debug('Submitted table: {}'.format(model.__tablename__))
     log.debug('Submitted kwargs: {}'.format(kwargs))
     # We need to get our engine back from our session to create an inspector.

--- a/harvdev_utils/chado_functions/get_create_or_update.py
+++ b/harvdev_utils/chado_functions/get_create_or_update.py
@@ -35,8 +35,6 @@ def get_create_or_update(session, model, **kwargs):
         log.critical('This function does not work for tables with rank.')
         sys.exit(-1)
 
-
-
     try:
         attempt = session.query(model).filter_by(**kwargs).one()
         log.debug('Found previous entry for %s, create or update not required.' % (kwargs))


### PR DESCRIPTION
A new function for working with Chado. Used for entries without rank when trying to get, create, or _update_ an entry.

Example use case: Updating a dbxref entry by adding a description.

**Existing entry:**
```
db_id = 110
accession = 'ZDB-GENE-131119-3'
```
**Updated entry:**
```
db_id = 110
accession = 'ZDB-GENE-131119-3'
description = 'MOD dbxref'
```

This function first checks for the existence of the target "updated" entry with 3 fields. If this fails, it then checks for the table constraints (in this case, `db_id` and `accession`). If it finds an existing entry with these constraints, it updates all the values of this entry to match the updated values. In this example it would update the description (previously `null`). If it does not find an existing entry with these constraints, it creates an entirely new entry.

This is different functionality than `get_or_create`. Using `get_or_create` would fail in this case -- it would _not_ find the target updated entry (because nothing exists with those 3 exact fields) but when attempting to create a new entry, a `UniqueViolation` error would be raised because an entry already exists with the same `db_id` and `accession`. Therefore, an update is necessary in these cases.