### PR TITLE
Refine

### DIFF
--- a/harvdev_utils/psycopg_functions/get_db_info.py
+++ b/harvdev_utils/psycopg_functions/get_db_info.py
@@ -301,7 +301,7 @@ def add_unique_info(data_dict, attribute, db_connection, sql_query, *arguments):
     add_cnt = 0
     for row in db_results:
         row_key, row_value = get_key_value(row)
-        confirm_attribute(data_dict, row_key)
+        # confirm_attribute(data_dict, row_key)    # This is too stringent, assumes input data has all relevant features.
         try:
             target = data_dict[row_key]
         except KeyError:

--- a/harvdev_utils/psycopg_functions/get_db_info.py
+++ b/harvdev_utils/psycopg_functions/get_db_info.py
@@ -301,7 +301,6 @@ def add_unique_info(data_dict, attribute, db_connection, sql_query, *arguments):
     add_cnt = 0
     for row in db_results:
         row_key, row_value = get_key_value(row)
-        # confirm_attribute(data_dict, row_key)    # This is too stringent, assumes input data has all relevant features.
         try:
             target = data_dict[row_key]
         except KeyError:


### PR DESCRIPTION
The function is intended to line up some dictionary that is being processed with chado sql results by matching dictionary keys with first column in sql results. The line deleted was raising an error if a key in db results was not in the dictionary being processed. This is too stringent, as sometimes the dictionary being handled represents a subset of some object in chado.