### PR TITLE
remove  extra space from column header line

### DIFF
--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -142,7 +142,7 @@ def tsv_report_dump(tsv_data_object, output_filename, **kwargs):
         log.debug('The "tsv_data_object" has no "metaData" key.')
 
     # Regardless of presence/absence of metaData, write out headers.
-    output_file.write('## ')
+    output_file.write('##')
     csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore')
     csv_writer.writeheader()
 


### PR DESCRIPTION
This removes a space that was occurring between the leading "##" and the label for the first column in bulk reports.