### PR TITLE
DB-787: Allow for many note lines in TSV headers

### DIFF
--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -137,8 +137,15 @@ def tsv_report_dump(tsv_data_object, output_filename, **kwargs):
         output_file.write('## {}\n'.format(tsv_data_object['metaData']['title']))
         output_file.write('## Generated: {}\n'.format(tsv_data_object['metaData']['dateProduced']))
         output_file.write('## Using datasource: {}\n'.format(tsv_data_object['metaData']['database']))
-        if 'note' in tsv_data_object['metaData'].keys():
-            output_file.write('## Note: {}\n'.format(tsv_data_object['metaData']['note']))
+        try:
+            note = tsv_data_object['metaData']['note']
+            if type(note) is list:
+                for note_part in note:
+                    output_file.write('## Note: {}\n'.format(note_part))
+            else:
+                output_file.write('## Note: {}\n'.format(note))
+        except KeyError:
+            pass
         output_file.write('##\n')
     except KeyError:
         log.debug('The "tsv_data_object" has no "metaData" key.')


### PR DESCRIPTION
Tested and works for both scripts that have a string or a list for the 'note' field.