### PR TITLE
Tweak setup

### DIFF
--- a/harvdev_utils/psycopg_functions/set_up_db_reading.py
+++ b/harvdev_utils/psycopg_functions/set_up_db_reading.py
@@ -68,15 +68,30 @@ def set_up_db_reading(report_label):
         username = os.environ['USER']
         password = os.environ['PGPASSWORD']
         database_release = os.environ['RELEASE']
-        assembly = os.environ['ASSEMBLY']
-        annotation_release = os.environ['ANNOTATIONRELEASE']
-        alliance_schema = os.environ['ALLIANCESCHEMA']
-        alliance_release = os.environ['ALLIANCERELEASE']
-        svn_username = os.environ['SVNUSER']
-        svn_password = os.environ['SVNPASSWORD']
         output_dir = '/src/output/'
         input_dir = '/src/input/'
         log_dir = '/src/logs/'
+        # Optional:
+        try:
+            assembly = os.environ['ASSEMBLY']
+        except KeyError:
+            assembly = 'unspecified'
+        try:
+            annotation_release = os.environ['ANNOTATIONRELEASE']
+        except KeyError:
+            annotation_release = 'unspecified'
+        try:
+            alliance_schema = os.environ['ALLIANCESCHEMA']
+            alliance_release = os.environ['ALLIANCERELEASE']
+        except KeyError:
+            alliance_schema = 'unspecified'
+            alliance_release = 'unspecified'
+        try:
+            svn_username = os.environ['SVNUSER']
+            svn_password = os.environ['SVNPASSWORD']
+        except KeyError:
+            svn_username = 'unspecified'
+            svn_password = 'unspecified'
 
     # Send values to a dict.
     set_up_dict = {}

--- a/harvdev_utils/psycopg_functions/set_up_db_reading.py
+++ b/harvdev_utils/psycopg_functions/set_up_db_reading.py
@@ -71,19 +71,17 @@ def set_up_db_reading(report_label):
         output_dir = '/src/output/'
         input_dir = '/src/input/'
         log_dir = '/src/logs/'
-        # Optional:
-        try:
-            assembly = os.environ['ASSEMBLY']
-        except KeyError:
-            assembly = 'unspecified'
+        # Optional variables:
         try:
             annotation_release = os.environ['ANNOTATIONRELEASE']
         except KeyError:
             annotation_release = 'unspecified'
         try:
+            assembly = os.environ['ASSEMBLY']
             alliance_schema = os.environ['ALLIANCESCHEMA']
             alliance_release = os.environ['ALLIANCERELEASE']
         except KeyError:
+            assembly = 'unspecified'
             alliance_schema = 'unspecified'
             alliance_release = 'unspecified'
         try:


### PR DESCRIPTION
Making specification of some env vars optional to simplify GoCD commands (and avoid having to specify values irrelevant to some scripts).