### PR TITLE
alt way to make options and set default values

### DIFF
--- a/harvdev_utils/psycopg_functions/set_up_db_reading.py
+++ b/harvdev_utils/psycopg_functions/set_up_db_reading.py
@@ -72,12 +72,26 @@ def set_up_db_reading(report_label):
         input_dir = '/src/input/'
         log_dir = '/src/logs/'
         # Optional variables:
-        annotation_release = os.environ['ANNOTATIONRELEASE', 'unspecified']
-        assembly = os.environ['ASSEMBLY', 'R6']
-        alliance_schema = os.environ['ALLIANCESCHEMA', 'unspecified']
-        alliance_release = os.environ['ALLIANCERELEASE', 'unspecified']
-        svn_username = os.environ['SVNUSER', 'unspecified']
-        svn_password = os.environ['SVNPASSWORD', 'unspecified']
+        try:
+            assembly = os.environ['ASSEMBLY']
+        except KeyError:
+            assembly = 'R6'
+        try:
+            annotation_release = os.environ['ANNOTATIONRELEASE']
+        except KeyError:
+            annotation_release = 'unspecified'
+        try:
+            alliance_schema = os.environ['ALLIANCESCHEMA']
+            alliance_release = os.environ['ALLIANCERELEASE']
+        except KeyError:
+            alliance_schema = 'unspecified'
+            alliance_release = 'unspecified'
+        try:
+            svn_username = os.environ['SVNUSER']
+            svn_password = os.environ['SVNPASSWORD']
+        except KeyError:
+            svn_username = 'unspecified'
+            svn_password = 'unspecified'
 
     # Send values to a dict.
     set_up_dict = {}


### PR DESCRIPTION
Reverting suggested change to optional vars in set_up_db_reading dict because I just got this error: `TypeError: str expected, not tuple`. Really thought I tested the suggestion (e.g., `assembly = os.environ['ASSEMBLY', 'R6']) - maybe I didn't, or maybe I'm doing something else wrong. In any case, code in this PR does work for me in the GoCD env that I use.