### PR TITLE
Fix optional variables

### DIFF
--- a/harvdev_utils/psycopg_functions/set_up_db_reading.py
+++ b/harvdev_utils/psycopg_functions/set_up_db_reading.py
@@ -72,12 +72,26 @@ def set_up_db_reading(report_label):
         input_dir = '/src/input/'
         log_dir = '/src/logs/'
         # Optional variables:
-        annotation_release = os.environ['ANNOTATIONRELEASE', 'unspecified']
-        assembly = os.environ['ASSEMBLY', 'R6']
-        alliance_schema = os.environ['ALLIANCESCHEMA', 'unspecified']
-        alliance_release = os.environ['ALLIANCERELEASE', 'unspecified']
-        svn_username = os.environ['SVNUSER', 'unspecified']
-        svn_password = os.environ['SVNPASSWORD', 'unspecified']
+        try:
+            assembly = os.environ['ASSEMBLY']
+        except KeyError:
+            assembly = 'R6'
+        try:
+            annotation_release = os.environ['ANNOTATIONRELEASE']
+        except KeyError:
+            annotation_release = 'unspecified'
+        try:
+            alliance_schema = os.environ['ALLIANCESCHEMA']
+            alliance_release = os.environ['ALLIANCERELEASE']
+        except KeyError:
+            alliance_schema = 'unspecified'
+            alliance_release = 'unspecified'
+        try:
+            svn_username = os.environ['SVNUSER']
+            svn_password = os.environ['SVNPASSWORD']
+        except KeyError:
+            svn_username = 'unspecified'
+            svn_password = 'unspecified'
 
     # Send values to a dict.
     set_up_dict = {}

--- a/harvdev_utils/psycopg_functions/set_up_db_reading.py
+++ b/harvdev_utils/psycopg_functions/set_up_db_reading.py
@@ -72,26 +72,12 @@ def set_up_db_reading(report_label):
         input_dir = '/src/input/'
         log_dir = '/src/logs/'
         # Optional variables:
-        try:
-            assembly = os.environ['ASSEMBLY']
-        except KeyError:
-            assembly = 'R6'
-        try:
-            annotation_release = os.environ['ANNOTATIONRELEASE']
-        except KeyError:
-            annotation_release = 'unspecified'
-        try:
-            alliance_schema = os.environ['ALLIANCESCHEMA']
-            alliance_release = os.environ['ALLIANCERELEASE']
-        except KeyError:
-            alliance_schema = 'unspecified'
-            alliance_release = 'unspecified'
-        try:
-            svn_username = os.environ['SVNUSER']
-            svn_password = os.environ['SVNPASSWORD']
-        except KeyError:
-            svn_username = 'unspecified'
-            svn_password = 'unspecified'
+        assembly = os.environ.get('ASSEMBLY', 'R6')
+        annotation_release = os.environ.get('ANNOTATIONRELEASE', 'unspecified')
+        alliance_schema = os.environ.get('ALLIANCESCHEMA', 'unspecified')
+        alliance_release = os.environ.get('ALLIANCERELEASE', 'unspecified')
+        svn_username = os.environ.get('SVNUSER', 'unspecified')
+        svn_password = os.environ.get('SVNPASSWORD', 'unspecified')
 
     # Send values to a dict.
     set_up_dict = {}


### PR DESCRIPTION
I must not have tested this correctly. Fixed now. Using `os.environ.get()` method works for providing default when env value not available.