### PR TITLE
DB-813: specify line endings for csv.DictWriter to remove odd chars in output files.

### DIFF
--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -153,7 +153,7 @@ def tsv_report_dump(tsv_data_object, output_filename, print_footer=True, **kwarg
 
     # Regardless of presence/absence of metaData, write out headers.
     output_file.write('#')
-    csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore', newline='')
+    csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore', lineterminator='\n')
     csv_writer.writeheader()
 
     for data_item in tsv_data_object['data']:

--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -153,7 +153,7 @@ def tsv_report_dump(tsv_data_object, output_filename, print_footer=True, **kwarg
 
     # Regardless of presence/absence of metaData, write out headers.
     output_file.write('#')
-    csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore')
+    csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore', line_terminator='\n')
     csv_writer.writeheader()
 
     for data_item in tsv_data_object['data']:

--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -153,7 +153,7 @@ def tsv_report_dump(tsv_data_object, output_filename, print_footer=True, **kwarg
 
     # Regardless of presence/absence of metaData, write out headers.
     output_file.write('#')
-    csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore', line_terminator='\n')
+    csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore', newline='')
     csv_writer.writeheader()
 
     for data_item in tsv_data_object['data']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ docutils>=0.14
 filelock>=3.0.10
 flake8>=3.5.0
 future>=0.17.1
+greenlet==1.1.3
 idna>=2.8
 imagesize>=1.1.0
 Jinja2>=2.10


### PR DESCRIPTION
Also installing a specific version of greenlet as latest version is causing errors upon installation of modules; I believe that greenlet is used by sqlalchemy.