### PR TITLE
DB-995: Flexible handling for empty data lists when dumping export files; some flake8.

### DIFF
--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -68,10 +68,10 @@ def check_data_object(data_object, override):
 
     # Check that the "data_object["data"]" list is not empty.
     if len(data_object['data']) == 0 and override is False:
-        log.error('The "data_object["data"]" object is empty.')
+        log.error('The "data_object["data"]" list is empty.')
         raise ValueError
     elif len(data_object['data']) == 0 and override is True:
-        log.warning('The "data_object["data"]" object is empty.')
+        log.warning('The "data_object["data"]" list is empty.')
         empty_data_list = True
 
     # Check that the "data_object["data"]" list elements are themselves dicts.

--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -18,14 +18,15 @@ from harvdev_utils.general_functions import timenow
 log = logging.getLogger(__name__)
 
 
-def check_data_object(data_object):
+def check_data_object(data_object, override):
     """Check the structure of the input data dict object before writing to file.
 
     Args:
-        arg1 (dict): A dictionary that includes a "metaData" key, and a "data" key with a list type value.
+        data_object (dict): A dictionary that includes a "metaData" key, and a "data" key with a list type value.
+        override (boolean): If True, does not raise an exception for empty "data" list.
 
     Returns:
-        None. Simply a check.
+        empty_data_list (boolean): True if data file is empty.
 
     Warnings:
         Will raise a warning if the "data_object" dict has no "metaData" key.
@@ -39,6 +40,8 @@ def check_data_object(data_object):
 
     """
     log.info('TIME: {}. Checking format of input data.'.format(timenow()))
+
+    empty_data_list = False
 
     # Check that the "data_object" is a dict.
     if type(data_object) != dict:
@@ -64,9 +67,12 @@ def check_data_object(data_object):
         raise TypeError
 
     # Check that the "data_object["data"]" list is not empty.
-    if len(data_object['data']) == 0:
+    if len(data_object['data']) == 0 and override is False:
         log.error('The "data_object["data"]" object is empty.')
         raise ValueError
+    elif len(data_object['data']) == 0 and override is True:
+        log.warning('The "data_object["data"]" object is empty.')
+        empty_data_list = True
 
     # Check that the "data_object["data"]" list elements are themselves dicts.
     for datum in data_object['data']:
@@ -74,6 +80,7 @@ def check_data_object(data_object):
             log.error('Elements of the data_object["data"] list are not of expected type dict.')
             raise TypeError
 
+    return empty_data_list
 
 def json_dump(json_data_object, output_filename):
     """Write "tsv_data_object" dict to JSON file.
@@ -87,15 +94,11 @@ def json_dump(json_data_object, output_filename):
 
     """
     log.info('TIME: {}. Writing data to output JSON file.'.format(timenow()))
-
-    check_data_object(json_data_object)
-
+    check_data_object(json_data_object, False)
     with open(output_filename, 'w') as outfile:
         json.dump(json_data_object, outfile, sort_keys=True, indent=2, separators=(',', ': '))
         outfile.close()
-
     log.info('TIME: {}. Done writing data to output file.'.format(timenow()))
-
     return
 
 
@@ -106,8 +109,11 @@ def tsv_report_dump(tsv_data_object, output_filename, print_footer=True, **kwarg
         arg1 (tsv_data_object): (dict) A data dict. It should have metaData and data keys.
         arg2 (output_filename): (str) The name to use for the output file.
         arg3 (print_footer): (bool) Whether to print out footer or not (default is true).
-        **kwargs (list): An optional list of headers under the "headers" key: e.g., headers=['a', 'b', 'c']
 
+    Kwargs:
+        headers (list): An optional list of headers.
+        override (boolean): If True, no error returned for empty data.
+        
     Returns:
         None. It just writes out the dict to a TSV file.
 
@@ -116,9 +122,11 @@ def tsv_report_dump(tsv_data_object, output_filename, print_footer=True, **kwarg
 
     """
     log.info('TIME: {}. Writing data to output TSV file.'.format(timenow()))
-
-    check_data_object(tsv_data_object)
-
+    try:
+        override = kwargs['override']
+    except KeyError:
+        override = False
+    empty_data_file = check_data_object(tsv_data_object, override)
     # Can supply a list of headers under the keyword 'headers'.
     if 'headers' in kwargs.keys():
         headers = kwargs['headers']
@@ -156,8 +164,11 @@ def tsv_report_dump(tsv_data_object, output_filename, print_footer=True, **kwarg
     csv_writer = csv.DictWriter(output_file, fieldnames=headers, delimiter='\t', extrasaction='ignore', lineterminator='\n')
     csv_writer.writeheader()
 
-    for data_item in tsv_data_object['data']:
-        csv_writer.writerow(data_item)
+    if empty_data_file is True:
+        output_file.write('## NO DATA TO REPORT.\n')
+    else:
+        for data_item in tsv_data_object['data']:
+            csv_writer.writerow(data_item)
 
     if print_footer:
         try:

--- a/harvdev_utils/general_functions/dump_data_to_file.py
+++ b/harvdev_utils/general_functions/dump_data_to_file.py
@@ -44,7 +44,7 @@ def check_data_object(data_object, override):
     empty_data_list = False
 
     # Check that the "data_object" is a dict.
-    if type(data_object) != dict:
+    if type(data_object) is not dict:
         log.error('The "data_object" is not of the expected type "dict".')
         raise TypeError
 
@@ -62,7 +62,7 @@ def check_data_object(data_object, override):
         raise KeyError
 
     # Check that the "data_object["data"]" value is a list.
-    if type(data_object['data']) != list:
+    if type(data_object['data']) is not list:
         log.error('The "data_object["data"]" object is not of the expected type "list".')
         raise TypeError
 
@@ -76,11 +76,12 @@ def check_data_object(data_object, override):
 
     # Check that the "data_object["data"]" list elements are themselves dicts.
     for datum in data_object['data']:
-        if type(datum) != dict:
+        if type(datum) is not dict:
             log.error('Elements of the data_object["data"] list are not of expected type dict.')
             raise TypeError
 
     return empty_data_list
+
 
 def json_dump(json_data_object, output_filename):
     """Write "tsv_data_object" dict to JSON file.
@@ -113,7 +114,7 @@ def tsv_report_dump(tsv_data_object, output_filename, print_footer=True, **kwarg
     Kwargs:
         headers (list): An optional list of headers.
         override (boolean): If True, no error returned for empty data.
-        
+
     Returns:
         None. It just writes out the dict to a TSV file.
 

--- a/harvdev_utils/general_functions/write_proforma.py
+++ b/harvdev_utils/general_functions/write_proforma.py
@@ -197,7 +197,7 @@ def detect_proforma_type(data_object, field_to_proforma_dict):
     """
     log.debug('TIME: {}. Detecting proforma type for this object: {}'.format(timenow(), data_object))
     # First make sure it's a dictionary.
-    if type(data_object) != dict:
+    if type(data_object) is not dict:
         log.warning('Data object is not of expected type dictionary.')
         resolved_proforma_type = 'undetermined'
     # Scan the dictionary keys.


### PR DESCRIPTION
In the old way, the `check_data_object` function would raise an error if a list of dict objects for export (to print file) was empty. However, in some cases, this is possible and ok (e.g., new report for curators on uncharacterized genes with new pub associations). Anyway, I've added a way for the code to say that an empty list is ok (the `override` variable).