### PR TITLE
Updates to GenotypeAnnotation object

### DIFF
--- a/harvdev_utils/genotype_utilities/genotype_classes.py
+++ b/harvdev_utils/genotype_utilities/genotype_classes.py
@@ -158,6 +158,7 @@ class GenotypeAnnotation(object):
         """Propagate cgroup notes and errors up to the genotype."""
         for cgroup in self.cgroup_list:
             self.notes.extend(cgroup.notes)
+            self.warnings.extend(cgroup.warnings)
             self.errors.extend(cgroup.errors)
             for feature_dict in cgroup.features:
                 for old_id, new_id in feature_dict['input_features_replaced'].items():
@@ -573,6 +574,7 @@ class ComplementationGroup(object):
         self.cgroup_desc = None          # Will be sorted concatenation of component IDs.
         self.gene_locus_id = None        # Will be FBgn ID of gene if cgroup represents classical/insertion alleles of a gene.
         self.notes = []                  # Notes on mapping of specified feature to one more appropriate for Alliance submission.
+        self.warnings = []               # Warnings about the cgroup.
         self.errors = []                 # Error messages: if any, the cgroup (and related genotype) should not be processed.
 
     #####################
@@ -1033,8 +1035,8 @@ class ComplementationGroup(object):
             elif feature_dict['feature_id'] and feature_dict['parental_gene_feature_id']:
                 allele_gene_name = feature_dict['parental_gene_name']
         if allele_gene_name and bogus_symbol_gene_name and allele_gene_name != bogus_symbol_gene_name:
-            self.errors.append(f'For "{self.input_cgroup_str}", bogus symbol does not match paired allele')
-            self.log.error('Bogus symbol does not match paired allele.')
+            self.warnings.append(f'For "{self.input_cgroup_str}", bogus symbol does not match paired allele')
+            self.log.warning('Bogus symbol does not match paired allele.')
         return
 
     def _rank_cgroups(self):

--- a/harvdev_utils/genotype_utilities/genotype_classes.py
+++ b/harvdev_utils/genotype_utilities/genotype_classes.py
@@ -1015,7 +1015,7 @@ class ComplementationGroup(object):
         at_locus = False
         not_at_locus = False
         for feature_dict in self.features:
-            if feature_dict['feature_id'] and feature_dict['at_locus'] is True:
+            if feature_dict['feature_id'] and feature_dict['at_locus'] is True and feature_dict['type'] != 'bogus symbol':
                 at_locus = True
             elif feature_dict['feature_id'] and feature_dict['at_locus'] is False:
                 not_at_locus = True

--- a/harvdev_utils/genotype_utilities/genotype_classes.py
+++ b/harvdev_utils/genotype_utilities/genotype_classes.py
@@ -155,7 +155,7 @@ class GenotypeAnnotation(object):
         return
 
     def _propagate_cgroup_notes_and_errors(self):
-        """Propagate cgroup notes and errors up to the genotype."""
+        """Propagate cgroup notes, warnings, and errors up to the genotype."""
         for cgroup in self.cgroup_list:
             self.notes.extend(cgroup.notes)
             self.warnings.extend(cgroup.warnings)
@@ -657,7 +657,7 @@ class ComplementationGroup(object):
                 bogus_feature, _ = get_or_create(session, Feature, type_id=60494, organism_id=org_id, name=input_symbol, uniquename=input_symbol)
                 feature_dict['current_symbol'] = sub_sup_to_sgml(feature_dict['input_name'])
                 feature_dict['feature_id'] = bogus_feature.feature_id
-                feature_dict['uniquename'] = feature_dict['input_name']
+                feature_dict['uniquename'] = bogus_feature.uniquename
                 feature_dict['type'] = 'bogus symbol'
                 feature_dict['is_new'] = True
                 self.log.warning(f'No existing feature for bogus symbol {feature_dict["input_symbol"]}, so one was created.')

--- a/harvdev_utils/genotype_utilities/genotype_classes.py
+++ b/harvdev_utils/genotype_utilities/genotype_classes.py
@@ -845,7 +845,6 @@ class ComplementationGroup(object):
         """Get parental Drosophilid genes for each allele specified."""
         # Note - get the parental gene for the input allele, even if the allele is converted to an insertion in the output genotype.
         # self.log.debug(f'Getting parental gene(s) for this cgroup: "{self.input_cgroup_str}".')
-        input_symbol = feature_dict['input_symbol']
         rel_type = aliased(Cvterm, name='rel_type')
         org_prop_type = aliased(Cvterm, name='org_prop_type')
         for feature_dict in self.features:
@@ -855,6 +854,7 @@ class ComplementationGroup(object):
             # Skip non-at-locus or non-FBal features.
             if not feature_dict['at_locus'] or not feature_dict['input_uniquename'].startswith('FBal'):
                 continue
+            input_symbol = feature_dict['input_symbol']
             try:
                 filters = (
                     org_prop_type.name == 'taxgroup',

--- a/harvdev_utils/genotype_utilities/genotype_classes.py
+++ b/harvdev_utils/genotype_utilities/genotype_classes.py
@@ -647,7 +647,7 @@ class ComplementationGroup(object):
                 feature_dict['feature_id'] = component_result.feature_id
                 feature_dict['uniquename'] = component_result.uniquename
                 feature_dict['type'] = 'bogus symbol'
-                self.log.debug(f'"{input_symbol}" corresponds to {feature_dict["uniquename"]}.')
+                self.log.debug(f'"{input_symbol}" corresponds to bogus symbol {feature_dict["uniquename"]}.')
             except NoResultFound:
                 # Make a new bogus symbol feature if needed.
                 # self.log.warning(f'No existing bogus symbol feature found; create one for "{input_symbol}".')

--- a/harvdev_utils/genotype_utilities/genotype_classes.py
+++ b/harvdev_utils/genotype_utilities/genotype_classes.py
@@ -58,7 +58,6 @@ class ChadoCache:
         self._synonym_symbol_cvterm = None
         self._alliance_compliant_cvterm = None
 
-
     @property
     def flybase_db(self):
         """Get FlyBase db.db_id."""
@@ -805,11 +804,13 @@ class ComplementationGroup(object):
             # 4d. Do not map if there are many allele-associated constructs for the given pub.
             else:
                 msg = f'{initial_feature.name} ({initial_feature.uniquename}) has ambiguous mapping to many constructs'
-                self.log.debug(msg)
+                self.log.error(msg)
                 self.errors.append(msg)
                 return
 
     def _get_basic_feature_info(self, session, feature_dict):
+        if feature_dict['feature_id'] is None:
+            return
         feature_type = aliased(Cvterm, name='feature_type')
         synonym_type = aliased(Cvterm, name='synonym_type')
         filters = (

--- a/harvdev_utils/genotype_utilities/genotype_classes.py
+++ b/harvdev_utils/genotype_utilities/genotype_classes.py
@@ -1003,8 +1003,8 @@ class ComplementationGroup(object):
         cgroup_parental_genes = set(cgroup_parental_genes)
         if len(cgroup_parental_genes) > 1:
             self.gene_locus_id = None
-            self.errors.append(f'For "{self.input_cgroup_str}", classical alleles of many different genes share a cgroup.')
-            self.log.error('Alleles of many different genes share a cgroup.')
+            self.warnings.append(f'For "{self.input_cgroup_str}", classical alleles of many different genes share a cgroup.')
+            self.log.warning('Alleles of many different genes share a cgroup.')
         return
 
     def _check_cgroup_for_mix_of_classical_and_transgenic_alleles(self):


### PR DESCRIPTION
@christabone - If you could have GH copilot do an initial review, that would be helpful (I don't have a subscription). Thanks!

1. Do not process FBba balancers.
2. Capture warnings (in addition to errors and notes).
3. Handle SGML <up>, </up> in bogus symbol names properly, which are present in chado feature.name sometimes.
4. Just warn of ambiguous FBal-FBtp associations (genotype will still fail at a later step when lack of mapping is noted).
5. Limit parental gene lookup to Drosophilid classical alleles.
6. Exclude bogus symbol features from check for mixed classical/transgenic complementation groups.
7. Record non-matching bogus symbol as a warning, not an error. This is because in chado, bogus symbol names are not updated when paired allele symbols are, so a mismatch is not necessarily wrong.