### PR TITLE
Allow any port to be used by connection but default to 5432

### DIFF
--- a/harvdev_utils/psycopg_functions/establish_db_connection.py
+++ b/harvdev_utils/psycopg_functions/establish_db_connection.py
@@ -14,7 +14,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def establish_db_connection(database_host, database, username, password):
+def establish_db_connection(database_host, database, username, password, port=5432):
     """Establish a connection to some postgres db.
 
     Args:
@@ -22,12 +22,13 @@ def establish_db_connection(database_host, database, username, password):
         arg2 (str): The "database" name.
         arg3 (str): The "username".
         arg4 (str): The postgres "password".
+        arg5 (int): The "port" (default 5432).
 
     Returns:
         psycopg2.extensions.connection: A psycopg2 database connection object.
 
     """
-    conn_string = "host={} dbname={} user={} password='{}'".format(database_host, database, username, password)
+    conn_string = "host={} dbname={} user={} password='{}' port={}".format(database_host, database, username, password, port)
     db_connection = psycopg2.connect(conn_string)
     conn_description = 'Made connection to database {} on db_host {}.'.format(database, database_host)
 

--- a/harvdev_utils/psycopg_functions/set_up_db_reading.py
+++ b/harvdev_utils/psycopg_functions/set_up_db_reading.py
@@ -52,6 +52,7 @@ def set_up_db_reading(report_label):
         database = config['default']['Database']
         username = config['default']['User']
         password = config['default']['PGPassword']
+        port = config['default'].get('Port', '5432')
         database_release = config['default']['Release']
         epicycle = config['default']['Epicycle']
         assembly = config['default']['Assembly']
@@ -73,6 +74,7 @@ def set_up_db_reading(report_label):
         input_dir = '/src/input/'
         log_dir = '/src/logs/'
         # Optional variables:
+        port = os.environ.get('PORT', '5432')
         epicycle = os.environ.get('EPICYCLE', 'unspecified')
         assembly = os.environ.get('ASSEMBLY', 'R6')
         annotation_release = os.environ.get('ANNOTATIONRELEASE', 'unspecified')
@@ -103,7 +105,7 @@ def set_up_db_reading(report_label):
     set_up_dict['testing'] = args.testing
 
     # Output filename
-    formatter = logging.Formatter('%(asctime)s : %(levelname)s : Line No %(lineno)d : %(message)s')
+    formatter = logging.Formatter('%(asctime)s : %(levelname)s : %(filename)s : Line No %(lineno)d : %(message)s')
     alliance = args.alliance
     if alliance is True:
         set_up_dict['output_filename'] = output_dir + 'FB_' + alliance_schema + '_' + report_label + '.json'
@@ -129,7 +131,7 @@ def set_up_db_reading(report_label):
     set_up_dict['log'] = logging.getLogger(__name__)
 
     # Establish database connection.
-    set_up_dict['conn'], conn_description = establish_db_connection(server, database, username, password)
+    set_up_dict['conn'], conn_description = establish_db_connection(server, database, username, password, port)
 
     # Official timestamp for this script.
     set_up_dict['the_time'] = strict_rfc3339.now_to_rfc3339_localoffset()


### PR DESCRIPTION
When testing I would like to be able to run from not just the flysql boxes so want to be able to set up a tunnel and use that.
Port here should be optional.