### PR TITLE
fix(chemical): guard ChEBI lookup against null default_structure/names

### DIFF
--- a/harvdev_utils/chado_functions/external_lookups.py
+++ b/harvdev_utils/chado_functions/external_lookups.py
@@ -201,14 +201,14 @@ class ExternalLookup:
             return self
 
         top = data[external_id]['data']
-        if 'default_structure' in top and 'standard_inchi_key' in top['default_structure']:
+        if top.get('default_structure') and 'standard_inchi_key' in top['default_structure']:
             self.inchikey = top['default_structure']['standard_inchi_key']
 
         if 'definition' in top:
             self.description = top['definition']
         if 'ascii_name' in top:
             self.name = top['ascii_name']
-        if 'names' in top and 'SYNONYM' in top['names']:
+        if top.get('names') and 'SYNONYM' in top['names']:
             syns = top['names']['SYNONYM']
             seen_it = set()
             synonyms = []


### PR DESCRIPTION
The EBI ChEBI API can return default_structure or names as null (e.g. CHEBI:6457 lignin). The membership tests then ran 'x in None', raising "TypeError: argument of type 'NoneType' is not iterable", which aborted the whole proforma load. Use top.get(...) truthy checks so missing keys and explicit nulls are handled safely.